### PR TITLE
cross-build to 2.11, 2.12 & 2.13

### DIFF
--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -2,7 +2,7 @@ lazy val V = _root_.scalafix.sbt.BuildInfo
 inThisBuild(
   List(
     scalaVersion := V.scala212,
-    crossScalaVersions := List(V.scala212, V.scala213),
+    crossScalaVersions := List(V.scala211, V.scala212, V.scala213),
     addCompilerPlugin(scalafixSemanticdb),
     scalacOptions += "-Yrangepos",
     organization := "com.geirsson",

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -20,7 +20,7 @@ inThisBuild(
 
 lazy val rules = project.settings(
   moduleName := "example-scalafix-rule",
-  libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % V.scalafix
+  libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % V.scalafixVersion
 )
 
 lazy val input = project
@@ -29,7 +29,7 @@ lazy val output = project
 
 lazy val tests = project
   .settings(
-    libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.scalafix % Test cross CrossVersion.full,
+    libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.scalafixVersion % Test cross CrossVersion.full,
     scalafixTestkitOutputSourceDirectories :=
       sourceDirectories.in(output, Compile).value,
     scalafixTestkitInputSourceDirectories :=

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -2,6 +2,7 @@ lazy val V = _root_.scalafix.sbt.BuildInfo
 inThisBuild(
   List(
     scalaVersion := V.scala212,
+    crossScalaVersions := List(V.scala212, V.scala213),
     addCompilerPlugin(scalafixSemanticdb),
     scalacOptions += "-Yrangepos",
     organization := "com.geirsson",

--- a/scalafix/project/build.properties
+++ b/scalafix/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.3.11

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.1")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.6.0-M14-3")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.16")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.2")
 

--- a/scalafix/rules/src/main/scala/fix/Examplescalafixrule_v1.scala
+++ b/scalafix/rules/src/main/scala/fix/Examplescalafixrule_v1.scala
@@ -21,14 +21,14 @@ object ExampleSyntaxRule extends v0.Rule("v0Rule") {
 }
 
 class Syntactic extends v1.SyntacticRule("SyntacticRule") {
-  override def fix(implicit doc: v1.Doc): v1.Patch = {
+  override def fix(implicit doc: v1.SyntacticDocument): v1.Patch = {
     if (doc.input.text.contains(s"// v1 $name!")) v0.Patch.empty
     else v0.Patch.addRight(doc.tree, s"// v1 $name!\n")
   }
 }
 
 class Semantic extends v1.SemanticRule("SemanticRule") {
-  override def fix(implicit doc: v1.SemanticDoc): v1.Patch = {
+  override def fix(implicit doc: v1.SemanticDocument): v1.Patch = {
     if (doc.input.text.contains(s"// v1 $name!")) v1.Patch.empty
     else v1.Patch.addRight(doc.tree, s"// v1 $name!\n")
   }


### PR DESCRIPTION
This is [used a lot in sbt-scalafix scripted tests](https://github.com/scalacenter/sbt-scalafix/search?q=example-scalafix-rule&unscoped_q=example-scalafix-rule), so having it published for 2.13 is a good start to make it possible to run 2.13 scalafix in sbt-scalafix.

I guess publish is manual?