### PR TITLE
ubuntu-latest now points to 24.04 which does not include sbt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v13
+      - uses: actions/checkout@v4
+      - uses: coursier/setup-action@v1
+      - uses: sbt/setup-sbt@v1
       - run: cd scalafix && sbt test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v13
+      - uses: actions/checkout@v4
+      - uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:8
+      - uses: sbt/setup-sbt@v1
       - uses: olafurpg/setup-gpg@v3
       - run: git fetch --unshallow
       - name: Publish ${{ github.ref }}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.8


### PR DESCRIPTION
also move away from deprecated olafurpg/setup-scala

https://github.com/actions/runner-images/issues/10767